### PR TITLE
Feature/connect ocr to frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 .DS_Store
 .python-version
 node_modules
-PaddleOCR
+
+# Python
+__pycache__

--- a/backend/api/utils.js
+++ b/backend/api/utils.js
@@ -10,12 +10,13 @@ async function parseOCRText(text) {
     ------------------------------------------------------------------------------------------
     ${text}
     ------------------------------------------------------------------------------------------
-    Return your response as a single, valid JSON object. Do not include any introductory text or any surrounding markdown or other text
+    Return your response as a single, valid JSON object. Do not include any introductory text or any surrounding markdown or other text.
     Here is the format:
     {
         "name":         ""
         "strength":     ""
-    }`;
+    }
+    `;
 
     const url = `${OLLAMA_API_URL}/api/generate`
     const options = {
@@ -32,14 +33,30 @@ async function parseOCRText(text) {
 
     const response = await fetch(url, options)
     if (!response.ok) {
-        const errorResponse = await response.json();
-        throw new Error(`Error ${response.status}: ${errorResponse.message}`);
+        const errorMessage = await response.json();
+        const errorStatus = response.status;
+
+        const error = new Error(errorMessage);
+        error.status = errorStatus;
+        throw error;
     }
 
     const jsonResponse = await response.json();
     const medicationInformation = jsonResponse.response;
 
-    return (JSON.parse(medicationInformation));
+    let parsedMedicationInformation;
+    try {
+        parsedMedicationInformation = JSON.parse(medicationInformation)
+    } catch (e) {
+        const errorMessage = e.message;
+        const errorStatus = 500;
+
+        const error = new Error(errorMessage);
+        error.status = errorStatus;
+        throw error;
+    }
+
+    return (parsedMedicationInformation);
 }
 
 async function runOCROnImage(medicationImage) {

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Python
+__pycache__

--- a/frontend/src/Patient/PatientComponents/MedicationUploadPageComponents/MedicationCamera.jsx
+++ b/frontend/src/Patient/PatientComponents/MedicationUploadPageComponents/MedicationCamera.jsx
@@ -7,11 +7,6 @@ function MedicationWebcam({ imgSrc, setImgSrc, setMedicationInformation }) {
 
     const processCapture = useCallback(() => {
         (async () => {
-            // If we already have an image, reset it
-            if (imgSrc !== null) {
-                setImgSrc(null);
-            }
-
             const image = webcamRef.current.getScreenshot();
             setImgSrc(image);
 

--- a/frontend/src/Patient/PatientComponents/MedicationUploadPageComponents/MedicationCamera.jsx
+++ b/frontend/src/Patient/PatientComponents/MedicationUploadPageComponents/MedicationCamera.jsx
@@ -1,10 +1,24 @@
+import { useCallback, useRef } from 'react';
 import Webcam from 'react-webcam'
 
-function MedicationWebcam() {
+function MedicationWebcam({imgSrc, setImgSrc}) {
+    const webcamRef = useRef(null);
+
+    const capture = useCallback(() => {
+        const image = webcamRef.current.getScreenshot();
+        setImgSrc(image);
+    }, [webcamRef]);
 
     return (
-        <div className="overflow-hidden my-3 rounded-3">
-            <Webcam mirrored style={{objectFit: 'cover'}} />
+
+        <div className="overflow-hidden my-3 rounded-3 d-flex flex-column justify-content-center">
+            {
+                imgSrc ?
+                    <img src={imgSrc} alt="Image of medication" />
+                    :
+                    <Webcam ref={webcamRef} mirrored style={{ objectFit: 'cover' }} />
+            }
+            <button onClick={capture} className="btn btn-light w-100 p-4 mb-3 rounded-top-0 rounded-bottom-3">Take Photo</button>
         </div>
     );
 }

--- a/frontend/src/Patient/PatientComponents/MedicationUploadPageComponents/MedicationCamera.jsx
+++ b/frontend/src/Patient/PatientComponents/MedicationUploadPageComponents/MedicationCamera.jsx
@@ -1,12 +1,23 @@
 import { useCallback, useRef } from 'react';
+import * as API from '../../../api.js'
 import Webcam from 'react-webcam'
 
-function MedicationWebcam({imgSrc, setImgSrc}) {
+function MedicationWebcam({ imgSrc, setImgSrc, setMedicationInformation }) {
     const webcamRef = useRef(null);
 
-    const capture = useCallback(() => {
-        const image = webcamRef.current.getScreenshot();
-        setImgSrc(image);
+    const processCapture = useCallback(() => {
+        (async () => {
+            // If we already have an image, reset it
+            if (imgSrc !== null) {
+                setImgSrc(null);
+            }
+
+            const image = webcamRef.current.getScreenshot();
+            setImgSrc(image);
+
+            const medicationInformation = await API.runOCR(image);
+            setMedicationInformation(medicationInformation);
+        })();
     }, [webcamRef]);
 
     return (
@@ -16,9 +27,10 @@ function MedicationWebcam({imgSrc, setImgSrc}) {
                 imgSrc ?
                     <img src={imgSrc} alt="Image of medication" />
                     :
-                    <Webcam ref={webcamRef} mirrored style={{ objectFit: 'cover' }} />
+                    <Webcam ref={webcamRef} screenshotFormat="image/jpeg"
+                        style={{ objectFit: 'cover', transform: 'scaleX(-1)' }} />
             }
-            <button onClick={capture} className="btn btn-light w-100 p-4 mb-3 rounded-top-0 rounded-bottom-3">Take Photo</button>
+            <button onClick={processCapture} className="btn btn-light w-100 p-4 mb-3 rounded-top-0 rounded-bottom-3">Take Photo</button>
         </div>
     );
 }

--- a/frontend/src/Patient/PatientComponents/MedicationUploadPageComponents/MedicationInformationWidget.jsx
+++ b/frontend/src/Patient/PatientComponents/MedicationUploadPageComponents/MedicationInformationWidget.jsx
@@ -1,18 +1,28 @@
-import { medications } from "../../../../data";
+import Spinner from 'react-bootstrap/Spinner';
 
-function MedicationInformationWidget() {
-    const medication = medications[0];
-
+function MedicationInformationWidget({ medicationInformation }) {
     return (
         <>
             <section className="medication-information-view bg-body-secondary rounded-3 p-3 my-3">
                 <h2>Medication Information</h2>
-
-                {/* This information is test data. The way this data will be handled has not yet been decided */}
                 <h3>Name</h3>
-                <p>{medication.name}</p>
+                <div>
+                    {
+                        medicationInformation ?
+                            <p>{medicationInformation.name}</p>
+                            :
+                            <Spinner animation="border" role="status" />
+                    }
+                </div>
                 <h3>Strength</h3>
-                <p>{medication.strength}</p>
+                <div>
+                    {
+                        medicationInformation ?
+                            <p>{medicationInformation.strength}</p>
+                            :
+                            <Spinner animation="border" role="status" />
+                    }
+                </div>
             </section>
         </>
     );

--- a/frontend/src/Patient/PatientComponents/MedicationUploadPageComponents/ResetMedicationPhotoButton.jsx
+++ b/frontend/src/Patient/PatientComponents/MedicationUploadPageComponents/ResetMedicationPhotoButton.jsx
@@ -1,0 +1,11 @@
+function ResetMedicationPhotoButton({ setImgSrc }) {
+    function resetWebcamImage() {
+        setImgSrc(null);
+    }
+
+    return (
+        <button onClick={resetWebcamImage} className="btn btn-danger w-100 p-4 mb-3">Reset</button>
+    );
+}
+
+export default ResetMedicationPhotoButton;

--- a/frontend/src/Patient/PatientComponents/MedicationUploadPageComponents/RetakeMedicationPhotoButton.jsx
+++ b/frontend/src/Patient/PatientComponents/MedicationUploadPageComponents/RetakeMedicationPhotoButton.jsx
@@ -1,7 +1,0 @@
-function RetakeMedicationPhotoButton() {
-    return(
-        <button className="btn btn-danger w-100 p-4 mb-3">Retake</button>
-    );
-}
-
-export default RetakeMedicationPhotoButton;

--- a/frontend/src/Patient/pages/MedicationUploadPage.jsx
+++ b/frontend/src/Patient/pages/MedicationUploadPage.jsx
@@ -1,22 +1,25 @@
 import MedicationWebcam from "../PatientComponents/MedicationUploadPageComponents/MedicationCamera";
 import MedicationInformationWidget from "../PatientComponents/MedicationUploadPageComponents/MedicationInformationWidget";
 import ConfirmMedicationPhotoButton from "../PatientComponents/MedicationUploadPageComponents/ConfirmMedicationPhotoButton";
-import RetakeMedicationPhotoButton from "../PatientComponents/MedicationUploadPageComponents/RetakeMedicationPhotoButton";
+import ResetMedicationPhotoButton from "../PatientComponents/MedicationUploadPageComponents/ResetMedicationPhotoButton";
+import { useState } from "react";
 
 function MedicationUploadPage() {
-    return(
+    const [imgSrc, setImgSrc] = useState(null);
+
+    return (
         <div className="container text-left justify-content-left">
             <h1>Medication Upload</h1>
             <h2>Take a photo of your medication</h2>
 
             <div className="row d-flex flex-wrap">
                 <div className="col-sm">
-                    <MedicationWebcam />
+                    <MedicationWebcam imgSrc={imgSrc} setImgSrc={setImgSrc} />
                 </div>
 
                 <div className="col-sm">
                     <MedicationInformationWidget />
-                    <RetakeMedicationPhotoButton />
+                    <ResetMedicationPhotoButton setImgSrc={setImgSrc} />
                     <ConfirmMedicationPhotoButton />
                 </div>
             </div>

--- a/frontend/src/Patient/pages/MedicationUploadPage.jsx
+++ b/frontend/src/Patient/pages/MedicationUploadPage.jsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 
 function MedicationUploadPage() {
     const [imgSrc, setImgSrc] = useState(null);
+    const [medicationInformation, setMedicationInformation] = useState(null);
 
     return (
         <div className="container text-left justify-content-left">
@@ -14,11 +15,11 @@ function MedicationUploadPage() {
 
             <div className="row d-flex flex-wrap">
                 <div className="col-sm">
-                    <MedicationWebcam imgSrc={imgSrc} setImgSrc={setImgSrc} />
+                    <MedicationWebcam imgSrc={imgSrc} setImgSrc={setImgSrc} setMedicationInformation={setMedicationInformation} />
                 </div>
 
                 <div className="col-sm">
-                    <MedicationInformationWidget />
+                    <MedicationInformationWidget medicationInformation={medicationInformation} />
                     <ResetMedicationPhotoButton setImgSrc={setImgSrc} />
                     <ConfirmMedicationPhotoButton />
                 </div>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -168,3 +168,28 @@ export async function getMedicationsToApprove(providerId) {
 
     return (await response.json());
 }
+
+export async function runOCR(imgSrc) {
+    let imgBlob = await fetch(imgSrc).then(res => res.blob());
+
+    const form = new FormData();
+    form.append("medicationImage", imgBlob, "photo.jpg");
+
+    // Custom options const as POST/medications/run-ocr requiers a form instead of JSON
+    const response = await fetch(`${API_URL}/medications/run-ocr`, {
+        method: "POST",
+        body: form,
+    });
+
+    // If we recieved an error, return a JSON explaining the medication was unable to be parsed to the user
+    if (!response.ok) {
+        const errorResponse = {
+            name: "Unable to identify medication name.",
+            strength: "Unable to identify medication strength."
+        }
+
+        return errorResponse;
+    }
+
+    return (await response.json());
+}


### PR DESCRIPTION
### Medication Page
https://github.com/user-attachments/assets/b77ebf2a-8937-49e6-b649-efbd7d48a221

### Context
MediScan requires patients to be able to upload an image of their medication and have that image processed by an OCR service that extracts the medication name and strength, expediting the approval process for the provider, as they will have less information that they are required to parse from the image of the medication. This PR implements the connection of the existing OCR service to the frontend. Now, when patients visit the medication upload page, patients are able to take photos of their medications and have the extracted `name` and `strength` displayed on the screen and stored to be saved in the database.

### This Pull Request
- Implements `runOCR(imgSrc)` in `api.js` to make a request to `POST/medications/run-ocr` to extract medication `name` and `strength`
- Adds functionality to `react-webcam` to take photos and reset the webcam, allowing users to take photos of medications
- Corrects error handling in `parseOCRText(text)` to account for when `JSON.parse(...)` throws a syntax error. This may occur when the LLM doesn't return a valid JSON. In this case the error is picked up and a premade JSON detailing the error is sent to the frontend to be rendered and inform the user of the failure.

*Next Pull Request:*
Next PR will focus on implementing the reminder system to notify patients when they are to take their medications