### PR TITLE
Feature/implement calendar frontend

### DIFF
--- a/backend/api/server.js
+++ b/backend/api/server.js
@@ -372,7 +372,7 @@ server.get('/providers/:providerId/appointments', async (req, res, next) => {
 
         // Censor outgoing information if requestor is a patient
         if (role === AccountTypes.PATIENT) {
-            appointments.filter((appointment) => {
+            appointments.map((appointment) => {
                 if (appointment.patient.id !== patientId) {
                     return appointment.patient = null;
                 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "helmet": "^8.1.0",
+        "http-status-codes": "^2.3.0",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0"
       },
@@ -597,6 +598,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,6 +5,7 @@
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "helmet": "^8.1.0",
+    "http-status-codes": "^2.3.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0"
   },

--- a/backend/prisma/migrations/20250717203233_init/migration.sql
+++ b/backend/prisma/migrations/20250717203233_init/migration.sql
@@ -57,11 +57,41 @@ CREATE TABLE "Treatment" (
     CONSTRAINT "Treatment_pkey" PRIMARY KEY ("id")
 );
 
+-- CreateTable
+CREATE TABLE "Appointment" (
+    "id" SERIAL NOT NULL,
+    "patient_id" INTEGER NOT NULL,
+    "provider_id" INTEGER NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "duration_in_minutes" INTEGER NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "Appointment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProviderPreferences" (
+    "id" SERIAL NOT NULL,
+    "provider_id" INTEGER NOT NULL,
+    "start_hour" TEXT NOT NULL DEFAULT '09:00',
+    "end_hour" TEXT NOT NULL DEFAULT '17:00',
+    "available_days" TEXT[] DEFAULT ARRAY['m', 't', 'w', 'tr', 'f']::TEXT[],
+    "max_appointments_per_day" INTEGER NOT NULL DEFAULT 8,
+    "min_buffer_minutes" INTEGER NOT NULL DEFAULT 15,
+    "appointment_lead_time_min" INTEGER NOT NULL DEFAULT 120,
+    "future_appointment_limit" INTEGER NOT NULL DEFAULT 30,
+
+    CONSTRAINT "ProviderPreferences_pkey" PRIMARY KEY ("id")
+);
+
 -- CreateIndex
 CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "Treatment_patient_id_key" ON "Treatment"("patient_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProviderPreferences_provider_id_key" ON "ProviderPreferences"("provider_id");
 
 -- AddForeignKey
 ALTER TABLE "Patient" ADD CONSTRAINT "Patient_id_fkey" FOREIGN KEY ("id") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
@@ -83,3 +113,12 @@ ALTER TABLE "Treatment" ADD CONSTRAINT "Treatment_patient_id_fkey" FOREIGN KEY (
 
 -- AddForeignKey
 ALTER TABLE "Treatment" ADD CONSTRAINT "Treatment_provider_id_fkey" FOREIGN KEY ("provider_id") REFERENCES "Provider"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Appointment" ADD CONSTRAINT "Appointment_provider_id_fkey" FOREIGN KEY ("provider_id") REFERENCES "Provider"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Appointment" ADD CONSTRAINT "Appointment_patient_id_fkey" FOREIGN KEY ("patient_id") REFERENCES "Patient"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProviderPreferences" ADD CONSTRAINT "ProviderPreferences_provider_id_fkey" FOREIGN KEY ("provider_id") REFERENCES "Provider"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -92,8 +92,8 @@ model ProviderPreferences {
   id                        Int      @id @default(autoincrement())
   provider                  Provider @relation(fields: [provider_id], references: [id])
   provider_id               Int      @unique
-  start_hour                String   @default("09:00")
-  end_hour                  String   @default("17:00")
+  start_hour                String   @default(9)
+  end_hour                  String   @default(17)
   available_days            String[] @default(["m", "t", "w", "tr", "f"])
   max_appointments_per_day  Int      @default(8)
   min_buffer_minutes        Int      @default(15)

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -31,20 +31,23 @@ model User {
 }
 
 model Patient {
-  id           Int          @id
-  user         User         @relation(fields: [id], references: [id])
+  id           Int           @id
+  user         User          @relation(fields: [id], references: [id])
   medications  Medication[]
-  provider     Provider?    @relation(fields: [provider_id], references: [id])
+  Appointments  Appointment[]
+  provider     Provider?     @relation(fields: [provider_id], references: [id])
   provider_id  Int?
   treatment    Treatment?
   treatment_id Int?
 }
 
 model Provider {
-  id        Int         @id
-  user      User        @relation(fields: [id], references: [id])
-  patients  Patient[]
-  treatments Treatment[]
+  id                  Int                  @id
+  user                User                 @relation(fields: [id], references: [id])
+  appointments        Appointment[]
+  patients            Patient[]
+  treatments          Treatment[]
+  providerPreferences ProviderPreferences?
 }
 
 model Medication {
@@ -72,4 +75,28 @@ model Treatment {
   patient_id  Int          @unique
   provider    Provider     @relation(fields: [provider_id], references: [id])
   provider_id Int
+}
+
+model Appointment {
+  id                  Int       @id @default(autoincrement())
+  patient_id          Int
+  provider_id         Int
+  date                DateTime
+  duration_in_minutes Int
+  name                String
+  provider            Provider? @relation(fields: [provider_id], references: [id])
+  patient             Patient?  @relation(fields: [patient_id], references: [id])
+}
+
+model ProviderPreferences {
+  id                        Int      @id @default(autoincrement())
+  provider                  Provider @relation(fields: [provider_id], references: [id])
+  provider_id               Int      @unique
+  start_hour                String   @default("09:00")
+  end_hour                  String   @default("17:00")
+  available_days            String[] @default(["m", "t", "w", "tr", "f"])
+  max_appointments_per_day  Int      @default(8)
+  min_buffer_minutes        Int      @default(15)
+  appointment_lead_time_min Int      @default(120)
+  future_appointment_limit  Int      @default(30)
 }

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -30,6 +30,13 @@ const Provider = [
     { id: 9 },
 ];
 
+const ProviderPreferences = [
+    { provider_id: 7 },
+    { provider_id: 8 },
+    { provider_id: 9 },
+];
+
+
 /* ----------  PATIENT  ---------- */
 const Patient = [
     { id: 1, provider_id: 7, treatment_id: 1 },
@@ -39,6 +46,55 @@ const Patient = [
     { id: 5, provider_id: 9, treatment_id: 5 },
     { id: 6, provider_id: 9, treatment_id: 6 },
 ];
+
+/* ----------  APPOINTMENT  ---------- */
+const Appointment = [
+  // Provider 7 — Patients 1 & 2
+  { patient_id: 1, provider_id: 7, date: new Date('2025-07-14T09:00:00Z'), duration_in_minutes: 30, name: 'Checkup with Provider 7' },
+  { patient_id: 2, provider_id: 7, date: new Date('2025-07-14T09:45:00Z'), duration_in_minutes: 30, name: 'Consultation with Provider 7' },
+  { patient_id: 1, provider_id: 7, date: new Date('2025-07-14T10:30:00Z'), duration_in_minutes: 30, name: 'Follow-up with Provider 7' },
+  { patient_id: 2, provider_id: 7, date: new Date('2025-07-14T11:15:00Z'), duration_in_minutes: 30, name: 'Wellness visit with Provider 7' },
+  { patient_id: 1, provider_id: 7, date: new Date('2025-07-14T13:00:00Z'), duration_in_minutes: 30, name: 'Monitoring with Provider 7' },
+  { patient_id: 2, provider_id: 7, date: new Date('2025-07-14T13:45:00Z'), duration_in_minutes: 30, name: 'Lab results with Provider 7' },
+
+  { patient_id: 1, provider_id: 7, date: new Date('2025-07-16T09:00:00Z'), duration_in_minutes: 30, name: 'Checkup with Provider 7' },
+  { patient_id: 2, provider_id: 7, date: new Date('2025-07-16T09:45:00Z'), duration_in_minutes: 30, name: 'Consultation with Provider 7' },
+  { patient_id: 1, provider_id: 7, date: new Date('2025-07-16T10:30:00Z'), duration_in_minutes: 30, name: 'Follow-up with Provider 7' },
+  { patient_id: 2, provider_id: 7, date: new Date('2025-07-16T11:15:00Z'), duration_in_minutes: 30, name: 'Wellness visit with Provider 7' },
+  { patient_id: 1, provider_id: 7, date: new Date('2025-07-16T13:00:00Z'), duration_in_minutes: 30, name: 'Monitoring with Provider 7' },
+  { patient_id: 2, provider_id: 7, date: new Date('2025-07-16T13:45:00Z'), duration_in_minutes: 30, name: 'Lab results with Provider 7' },
+
+  // Provider 8 — Patients 3 & 4
+  { patient_id: 3, provider_id: 8, date: new Date('2025-07-14T09:00:00Z'), duration_in_minutes: 30, name: 'Checkup with Provider 8' },
+  { patient_id: 4, provider_id: 8, date: new Date('2025-07-14T09:45:00Z'), duration_in_minutes: 30, name: 'Consultation with Provider 8' },
+  { patient_id: 3, provider_id: 8, date: new Date('2025-07-14T10:30:00Z'), duration_in_minutes: 30, name: 'Follow-up with Provider 8' },
+  { patient_id: 4, provider_id: 8, date: new Date('2025-07-14T11:15:00Z'), duration_in_minutes: 30, name: 'Wellness visit with Provider 8' },
+  { patient_id: 3, provider_id: 8, date: new Date('2025-07-14T13:00:00Z'), duration_in_minutes: 30, name: 'Monitoring with Provider 8' },
+  { patient_id: 4, provider_id: 8, date: new Date('2025-07-14T13:45:00Z'), duration_in_minutes: 30, name: 'Lab results with Provider 8' },
+
+  { patient_id: 3, provider_id: 8, date: new Date('2025-07-16T09:00:00Z'), duration_in_minutes: 30, name: 'Checkup with Provider 8' },
+  { patient_id: 4, provider_id: 8, date: new Date('2025-07-16T09:45:00Z'), duration_in_minutes: 30, name: 'Consultation with Provider 8' },
+  { patient_id: 3, provider_id: 8, date: new Date('2025-07-16T10:30:00Z'), duration_in_minutes: 30, name: 'Follow-up with Provider 8' },
+  { patient_id: 4, provider_id: 8, date: new Date('2025-07-16T11:15:00Z'), duration_in_minutes: 30, name: 'Wellness visit with Provider 8' },
+  { patient_id: 3, provider_id: 8, date: new Date('2025-07-16T13:00:00Z'), duration_in_minutes: 30, name: 'Monitoring with Provider 8' },
+  { patient_id: 4, provider_id: 8, date: new Date('2025-07-16T13:45:00Z'), duration_in_minutes: 30, name: 'Lab results with Provider 8' },
+
+  // Provider 9 — Patients 5 & 6
+  { patient_id: 5, provider_id: 9, date: new Date('2025-07-14T09:00:00Z'), duration_in_minutes: 30, name: 'Checkup with Provider 9' },
+  { patient_id: 6, provider_id: 9, date: new Date('2025-07-14T09:45:00Z'), duration_in_minutes: 30, name: 'Consultation with Provider 9' },
+  { patient_id: 5, provider_id: 9, date: new Date('2025-07-14T10:30:00Z'), duration_in_minutes: 30, name: 'Follow-up with Provider 9' },
+  { patient_id: 6, provider_id: 9, date: new Date('2025-07-14T11:15:00Z'), duration_in_minutes: 30, name: 'Wellness visit with Provider 9' },
+  { patient_id: 5, provider_id: 9, date: new Date('2025-07-14T13:00:00Z'), duration_in_minutes: 30, name: 'Monitoring with Provider 9' },
+  { patient_id: 6, provider_id: 9, date: new Date('2025-07-14T13:45:00Z'), duration_in_minutes: 30, name: 'Lab results with Provider 9' },
+
+  { patient_id: 5, provider_id: 9, date: new Date('2025-07-16T09:00:00Z'), duration_in_minutes: 30, name: 'Checkup with Provider 9' },
+  { patient_id: 6, provider_id: 9, date: new Date('2025-07-16T09:45:00Z'), duration_in_minutes: 30, name: 'Consultation with Provider 9' },
+  { patient_id: 5, provider_id: 9, date: new Date('2025-07-16T10:30:00Z'), duration_in_minutes: 30, name: 'Follow-up with Provider 9' },
+  { patient_id: 6, provider_id: 9, date: new Date('2025-07-16T11:15:00Z'), duration_in_minutes: 30, name: 'Wellness visit with Provider 9' },
+  { patient_id: 5, provider_id: 9, date: new Date('2025-07-16T13:00:00Z'), duration_in_minutes: 30, name: 'Monitoring with Provider 9' },
+  { patient_id: 6, provider_id: 9, date: new Date('2025-07-16T13:45:00Z'), duration_in_minutes: 30, name: 'Lab results with Provider 9' },
+];
+
 
 
 /* ----------  TREATMENT  ---------- */
@@ -232,6 +288,9 @@ async function main() {
     }
     for (const medication of Medication) {
         await prisma.medication.create({ data: medication });
+    }
+    for (const appointment of Appointment) {
+        await prisma.appointment.create({ data: appointment });
     }
 
     console.log("Database seeded successfully!");

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "bootstrap": "^5.3.7",
         "jwt-decode": "^4.0.0",
         "react": "^19.1.0",
+        "react-big-calendar": "^1.19.4",
         "react-bootstrap": "^2.10.10",
         "react-dom": "^19.1.0",
         "react-router": "^7.6.2",
@@ -1727,6 +1728,15 @@
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1789,6 +1799,18 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/date-arithmetic": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-arithmetic/-/date-arithmetic-4.1.0.tgz",
+      "integrity": "sha512-QWxYLR5P/6GStZcdem+V1xoto6DMadYWpMXU82ES3/RfR3Wdwr3D0+be7mgOJ+Ov0G9D5Dmb9T17sNLQYj9XOg==",
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2209,6 +2231,11 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globalize": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/globalize/-/globalize-0.1.1.tgz",
+      "integrity": "sha512-5e01v8eLGfuQSOvx2MsDMOWS0GFtCx1wPzQSmcHw4hkxFzrQDBO3Xwg/m8Hr/7qXMrHeOIE29qWVzyv06u1TZA=="
+    },
     "node_modules/globals": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-16.2.0.tgz",
@@ -2433,6 +2460,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2462,6 +2501,21 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2470,6 +2524,27 @@
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
       },
       "engines": {
         "node": "*"
@@ -2709,6 +2784,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-big-calendar": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/react-big-calendar/-/react-big-calendar-1.19.4.tgz",
+      "integrity": "sha512-FrvbDx2LF6JAWFD96LU1jjloppC5OgIvMYUYIPzAw5Aq+ArYFPxAjLqXc4DyxfsQDN0TJTMuS/BIbcSB7Pg0YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "clsx": "^1.2.1",
+        "date-arithmetic": "^4.1.0",
+        "dayjs": "^1.11.7",
+        "dom-helpers": "^5.2.1",
+        "globalize": "^0.1.1",
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "luxon": "^3.2.1",
+        "memoize-one": "^6.0.0",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.40",
+        "prop-types": "^15.8.1",
+        "react-overlays": "^5.2.1",
+        "uncontrollable": "^7.2.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.14.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-bootstrap": {
       "version": "2.10.10",
       "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.10.tgz",
@@ -2763,6 +2866,26 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "license": "MIT"
+    },
+    "node_modules/react-overlays": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.2.1.tgz",
+      "integrity": "sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.8",
+        "@popperjs/core": "^2.11.6",
+        "@restart/hooks": "^0.4.7",
+        "@types/warning": "^3.0.0",
+        "dom-helpers": "^5.2.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "bootstrap": "^5.3.7",
     "jwt-decode": "^4.0.0",
     "react": "^19.1.0",
+    "react-big-calendar": "^1.19.4",
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.1.0",
     "react-router": "^7.6.2",

--- a/frontend/src/Apps/AppointmentManager/AppointmentManagerPage.jsx
+++ b/frontend/src/Apps/AppointmentManager/AppointmentManagerPage.jsx
@@ -1,7 +1,7 @@
 import { Calendar, momentLocalizer } from "react-big-calendar";
 import "react-big-calendar/lib/css/react-big-calendar.css";
-import { useCallback } from "react";
-import { useEffect } from "react";
+import { useEffect, useState, useCallback } from "react";
+import { useAuth } from "../../hooks/AuthProvider";
 import * as API from '../../api'
 import moment from 'moment'
 
@@ -25,20 +25,24 @@ function AppointmentManagerPage() {
         }
     ]
     */
-    const [appointments, setAppointments] = useState(null);
+    const [appointments, setAppointments] = useState([]);
+    const { user } = useAuth();
 
 
-    const fetchAppointments = useCallback(() => {
+    async function fetchAppointments(id, role) {
+        const appointments = await API.getAppointments(id, role);
+        setAppointments(appointments);
+    }
 
-    });
+    async function fetchAppointmentSuggestions() {
 
-    const fetchAppointmentSuggestions = useCallback(() => {
-
-    });
+    }
 
     useEffect(() => {
-        fetchAppointments();
-        fetchAppointmentSuggestions();
+        (async () => {
+            await fetchAppointments(user.id, user.role);
+            await fetchAppointmentSuggestions();
+        })();
     }, []);
 
 

--- a/frontend/src/Apps/AppointmentManager/AppointmentManagerPage.jsx
+++ b/frontend/src/Apps/AppointmentManager/AppointmentManagerPage.jsx
@@ -1,7 +1,107 @@
+import { Calendar, momentLocalizer } from "react-big-calendar";
+import "react-big-calendar/lib/css/react-big-calendar.css";
+import { useCallback } from "react";
+import { useEffect } from "react";
+import * as API from '../../api'
+import moment from 'moment'
+
+const localizer = momentLocalizer(moment);
+
 function AppointmentManagerPage() {
-    return(
-        <>
-        </>
+    /*
+    What appointments look like
+    const appointments = [
+        {
+            title: "Busy",
+            start: new Date("2025-07-17T10:00:00"),
+            end: new Date("2025-07-17T12:00:00"),
+            resource: { type: "busy" }
+        },
+        {
+            title: "Appointment",
+            start: new Date("2025-07-18T10:00:00"),
+            end: new Date("2025-07-18T12:00:00"),
+            resource: { type: "appointment" }
+        }
+    ]
+    */
+    const [appointments, setAppointments] = useState(null);
+
+
+    const fetchAppointments = useCallback(() => {
+
+    });
+
+    const fetchAppointmentSuggestions = useCallback(() => {
+
+    });
+
+    useEffect(() => {
+        fetchAppointments();
+        fetchAppointmentSuggestions();
+    }, []);
+
+
+    async function BookAppointment() {
+
+    }
+
+    return (
+        <div className="container">
+            <h1>Appointment Manager</h1>
+
+            <section className="appointment-suggestion-selector d-flex">
+                <div>
+                    <h2>
+                        Suggested Meeting Times
+                    </h2>
+                    <p>
+                        Select a suggested time for your appointment.
+                    </p>
+                </div>
+
+                <div className="form-check" name="appointment-suggestion" onChange={(e) => console.log(e)}>
+                    <div className="form-check form-check-inline">
+                        <input type="radio" className="form-check-input" name="appointment-suggestion" id="appointment-suggestion-1" />
+                        <label className="form-check-label" htmlFor="appointment-suggestion-radio">
+                            <strong>Appointment 1<br /></strong>
+                            <span>01:00 - 03:30</span>
+                        </label>
+                    </div>
+
+                    <div className="form-check form-check-inline">
+                        <input type="radio" className="form-check-input" name="appointment-suggestion" id="appointment-suggestion-2" />
+                        <label className="form-check-label" htmlFor="appointment-suggestion-radio">
+                            <strong>Appointment 2<br /></strong>
+                            <span>12:00 - 12:30</span>
+                        </label>
+                    </div>
+
+                    <div className="form-check form-check-inline">
+                        <input type="radio" className="form-check-input" name="appointment-suggestion" id="appointment-suggestion-3" />
+                        <label className="form-check-label" htmlFor="appointment-suggestion-radio">
+                            <strong>Appointment 3<br /></strong>
+                            <span>10:00 - 10:30</span>
+                        </label>
+                    </div>
+                </div>
+
+                <button className="btn btn-primary">
+                    Create Appointment
+                </button>
+            </section>
+
+            <Calendar
+                localizer={localizer}
+                events={appointments}
+                startAccessor="start"
+                style={{ height: "70vh" }}
+                defaultView="work_week"
+                views={["day", "work_week"]}
+                timeslots={4}
+                step={15}
+            />
+        </div>
     );
 }
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -176,6 +176,7 @@ export async function getMedicationsToApprove(providerId) {
 
 export async function getAppointments(id, role) {
     let providerId = id;
+    let url;
 
     // If a patient is requesting the information, find out the patient's provider
     // Then retrieve the censored appointments without other patients information
@@ -183,11 +184,12 @@ export async function getAppointments(id, role) {
         const patient = await getPatient(id);
         providerId = patient.provider_id;
 
-        const response = await fetchWithErrorHandling(`${API_URL}/providers/${providerId}/appointments?role=${role}&patientId=${id}`, getHttpOptions("GET"));
-        return (await response.json());
+        url = `${API_URL}/providers/${providerId}/appointments?role=${role}&patientId=${id}`;
+    } else {
+        url = `${API_URL}/providers/${providerId}/appointments`;
     }
 
     // If a provider requests the information, return the appointments with all information
-    const response = await fetchWithErrorHandling(`${API_URL}/providers/${providerId}/appointments`, getHttpOptions("GET"));
+    const response = await fetchWithErrorHandling(url, getHttpOptions("GET"));
     return (await response.json());
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,5 +1,10 @@
 const API_URL = import.meta.env.VITE_API_URL;
 
+const AccountTypes = {
+    PATIENT: "PATIENT",
+    PROVIDER: "PROVIDER"
+}
+
 async function fetchWithErrorHandling(url, options) {
     const response = await fetch(url, options);
     if (!response.ok) {
@@ -166,5 +171,23 @@ export async function getProviderPatients(providerId) {
 export async function getMedicationsToApprove(providerId) {
     const response = await fetchWithErrorHandling(`${API_URL}/providers/${providerId}/medicationsToApprove`, getHttpOptions("GET"));
 
+    return (await response.json());
+}
+
+export async function getAppointments(id, role) {
+    let providerId = id;
+
+    // If a patient is requesting the information, find out the patient's provider
+    // Then retrieve the censored appointments without other patients information
+    if (role === AccountTypes.PATIENT) {
+        const patient = await getPatient(id);
+        providerId = patient.provider_id;
+
+        const response = await fetchWithErrorHandling(`${API_URL}/providers/${providerId}/appointments?role=${role}?patientId=${id}`, getHttpOptions("GET"));
+        return (await response.json());
+    }
+
+    // If a provider requests the information, return the appointments with all information
+    const response = await fetchWithErrorHandling(`${API_URL}/providers/${providerId}/appointments`, getHttpOptions("GET"));
     return (await response.json());
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -183,7 +183,7 @@ export async function getAppointments(id, role) {
         const patient = await getPatient(id);
         providerId = patient.provider_id;
 
-        const response = await fetchWithErrorHandling(`${API_URL}/providers/${providerId}/appointments?role=${role}?patientId=${id}`, getHttpOptions("GET"));
+        const response = await fetchWithErrorHandling(`${API_URL}/providers/${providerId}/appointments?role=${role}&patientId=${id}`, getHttpOptions("GET"));
         return (await response.json());
     }
 


### PR DESCRIPTION
### Appointment Manager Page
<img width="5312" height="3342" alt="image" src="https://github.com/user-attachments/assets/cadd58bf-81ee-4a4a-834c-de869397050e" />

### Context
The second technical challenge for MediScan requires patients and providers to be able to schedule appointments with their, patients to be able to view their provider's schedule (excluding other patient's information), and for providers to be able to view their appointments. Providers and patients must also be able to use a smart scheduler to automatically suggest meetings that fall on optimal times. This PR focuses on implementing the frontend display for this feature.

### This PR
- Implements `AppointmentManagerPage` to display the suggested appointment times and schedule of the provider
- Adds `GET/providers/:providerId/appointments` endpoint to `server.js` to retrieve the appointments assigned to a provider.
  - Additionally, if a patient requests to see the appointments of a provider, they can only see detailed information regarding the patients appointments. All other appointments are displayed as "Busy." (Authorization for this route has to be added)
  - Adds `getAppointments(id, role)` to retrieve the appointments from `GET/providers/:providerId/appointments`
  - Adds `ProviderPreferences` and `Appointment` schemas
  - Adds seed data for `ProviderPreferences` and `Appointment`

*Next Pull Request:*
Next PR will focus on adding the smart scheduling suggestions