### PR TITLE
Corrects bug where appointments werent scheduled

### DIFF
--- a/frontend/src/Apps/AppointmentManager/AppointmentCreationModal.jsx
+++ b/frontend/src/Apps/AppointmentManager/AppointmentCreationModal.jsx
@@ -29,12 +29,12 @@ export default function AppointmentCreationModal({ user, appointment_duration, s
 
     async function handleAppointmentCreation(e) {
         e.preventDefault();
-
+        console.log("hi")
         try {
             if (!selectedPatient && user.role === AccountTypes.PROVIDER) {
                 throw new Error("Patient must be selected!")
             }
-            await API.postAppointment(user.id, user.role, date.getTime(), duration, name, selectedPatient);
+            await API.postAppointment(user.id, user.role, date.getTime(), duration, name, (selectedPatient || user.id));
 
             selectedSuggestedAppointment.title = name;
             setFormattedAppointments((prevAppointments) => [...prevAppointments, selectedSuggestedAppointment]);

--- a/frontend/src/Apps/AppointmentManager/AppointmentManagerPage.jsx
+++ b/frontend/src/Apps/AppointmentManager/AppointmentManagerPage.jsx
@@ -191,7 +191,7 @@ function AppointmentManagerPage() {
                     7
                 )}
             />
-            <button className="btn btn-primary m-2" onClick={setTogglePreferencesModal}>Edit Scheduling Preferences</button>
+            {user.role === "PROVIDER" && <button className="btn btn-primary m-2" onClick={setTogglePreferencesModal}>Edit Scheduling Preferences</button>}
 
             <AppointmentCreationModal user={user} appointment_duration={duration} selectedSuggestedAppointment={selectedSuggestedAppointment} setFormattedAppointments={setFormattedAppointments} show={toggleAppointmentModal} onHide={() => setToggleAppointmentModal(false)} />
             {user.role === "PROVIDER" && <ProviderPreferencesModal user={user} show={togglePreferencesModal} onHide={() => setTogglePreferencesModal(false)} />}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -249,7 +249,8 @@ export async function postAppointment(id, role, date, duration_in_minutes, name,
 
     if (role === AccountTypes.PATIENT) {
         patient_id = id;
-        provider_id = await getPatient(id).provider_id;
+        const patient = await getPatient(id);
+        provider_id = patient.provider_id;
     }
 
     if (role === AccountTypes.PROVIDER) {


### PR DESCRIPTION
### Context
When new users were made, a bug was discovered where scheduling for appointments did not occur. This was corrected in this PR by ensuring `provider_id `and `patient_id` were correctly handled. This is achieved by ensuring that the use case where a user is a `PROVIDER` or a `PATIENT` is handled correctly. 

`PATIENTS` did not have their appointments scheduled correctly due to a `null` `proivider_id` value being passed for the `postAppointment` function. Before, the `provider_id` was acquired by the line `const provider_id = await getPatient(id).provider_id;`. This would return `null`. Now the `provider_id` is handled more carefully as such:
```
const patient = await getPatient(id);
provider_id = patient.provider_id;
```