### PR TITLE
Adds html template for summary message

### DIFF
--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -137,7 +137,7 @@ const Medication = [
   {
     name: 'Glipizide',
     strength: '5 mg',
-    dose: 'Take one tablet orally before breakfast',
+    dose: '5 mg',
     photo_url: 'https://picsum.photos/seed/glipizide/200/200',
     patient_id: 3,
     treatment_id: 3,
@@ -167,7 +167,7 @@ const Medication = [
   {
     name: 'Budesonide + Formoterol',
     strength: '160/4.5 µg',
-    dose: 'Inhale 2 inhalations twice daily',
+    dose: '320/4.5 µg',
     photo_url: 'https://picsum.photos/seed/budesonide/200/200',
     patient_id: 5,
     treatment_id: 5,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -87,6 +87,18 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
 
+  bullboard:
+    image: nauverse/bull-board:latest
+    environment:
+      REDIS_URL: redis://redis:6379
+      BULL_VERSION: BULLMQ
+    ports:
+      - "3003:3000"
+    depends_on:
+      - redis
+    networks:
+      - mediscan-network
+
   minio:
       image: minio/minio:latest
       container_name: minio

--- a/reminderService/providerSummaryHelpers/providerSummaryWorker.js
+++ b/reminderService/providerSummaryHelpers/providerSummaryWorker.js
@@ -30,17 +30,63 @@ async function sendReminder(providerEmail, reminders) {
     const textBody = reminders.map((reminder) => {
         return (
             `
-            ${reminder.patientFirstName} took ${reminder.medicationName} with a dose of ${reminder.medicationDose} at ${reminder.sentAt}
+            <p style="box-sizing:border-box;margin:0px;overflow-wrap:break-word;max-width:none;padding-top:0.2em;font-size:1em;line-height:1.6em;color:#333333;">
+                ${reminder.patientFirstName} took ${reminder.medicationName} with a dose of ${reminder.medicationDose} at ${reminder.sentAt}
+            </p>
+            <p></p>
             `
         );
     });
+
+    const template = `
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Email</title><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Mulish:ital,wght@0,200..1000;1,200..1000&display=swap" rel="stylesheet">
+        </head>
+        <body style="background-color: #fafafa;">
+            <table style="box-sizing:border-box;margin:0px auto;font-family:Verdana, Geneva, Tahoma, sans-serif;border-spacing:0px;background-color:#ffffff;max-width:690px;" role="presentation">
+            <tbody style="box-sizing:border-box;margin:0px;">
+                <tr style="box-sizing:border-box;margin:0px;">
+                <td style="box-sizing:border-box;margin:0px;overflow-wrap:break-word;text-align:center;">
+                    <h2 style="box-sizing:border-box;margin:0;overflow-wrap:break-word;line-height:1.35em;font-size:36px;padding:0;border-bottom-style:none;color:#333333;text-align:center;">
+                    <strong style="box-sizing:border-box;margin:0px;">MediScan</strong>
+                    </h2>
+                </td>
+                </tr>
+                <tr style="box-sizing:border-box;margin:0px;">
+                <td style="box-sizing:border-box;margin:0px;overflow-wrap:break-word;text-align:center;">
+                    <h3 style="box-sizing:border-box;margin:0;overflow-wrap:break-word;line-height:1.35em;font-size:24px;padding:0;border-bottom-style:none;color:#333333;font-weight:400;text-align:center;">
+                    Hello!
+                    </h3>
+                </td>
+                </tr>
+                <tr style="box-sizing:border-box;margin:0px;">
+                <td style="box-sizing:border-box;margin:0px;overflow-wrap:break-word;text-align:center;">
+                    <p style="box-sizing:border-box;margin:0px;overflow-wrap:break-word;max-width:none;padding-top:0.2em;font-size:1em;line-height:1.6em;color:#333333;">
+                    Daily Provider Digest:
+                    </p>
+                    ${textBody.join('\n\n')}
+                </td>
+                </tr>
+                <tr style="box-sizing:border-box;margin:0px;">
+                <td style="box-sizing:border-box;margin:0px;overflow-wrap:break-word;background-color:#141517;height:30px;">
+                    <p style="box-sizing:border-box;margin:0px 0px calc(0.6em * 1.5);overflow-wrap:break-word;max-width:none;padding-top:0.2em;font-size:1em;line-height:1.6em;text-align:center;">
+                    <span style="box-sizing:border-box;margin:0px;color:#FFFFFF;">MediScan</span>
+                    </p>
+                </td>
+                </tr>
+            </tbody>
+            </table>
+        </body>
+        </html>
+    `;
 
     (async () => {
         const info = await transporter.sendMail({
             from: `"MediScan" <mediScan@gmail.com>`,
             to: `${providerEmail}`,
             subject: "Reminders Summary",
-            text: textBody.join('\n - ')
+            html: template
         });
 
         console.log(info);


### PR DESCRIPTION
### Bullboard
<img width="1896" height="1136" alt="Screenshot 2025-08-01 at 10 54 08 AM" src="https://github.com/user-attachments/assets/8c762da7-175a-4d01-8612-092e1bfe90f0" />

### Product Changes
#### Before
<img width="1453" height="250" alt="Screenshot 2025-08-01 at 10 58 01 AM" src="https://github.com/user-attachments/assets/a3f8019b-b6d6-48f2-9ae4-ecc2a3be8039" />

#### After
<img width="1453" height="319" alt="Screenshot 2025-08-01 at 10 58 13 AM" src="https://github.com/user-attachments/assets/6858c718-dd06-4c9c-9cd5-e0d159147dec" />

### Context
In order to improve the UI/UX of MediScan, the template for the emails to providers with a summary of the medications taken has been refactored to improve the look and legibility of the information. This was done by creating an HTML template to send the summary information as HTML instead of text. Additionally, bullboard has been added to better keep track of failed and successful jobs, improving the debugging experience of this feature.

### This PR
- Adds a template for HTML to `providerSummaryWorker`
- Adds bullboard to docker-compose

***Next PR***
Next PR will focus on improving the appointment manager UX